### PR TITLE
Fix certificate import

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ And use it to create the root certificate:
 ```console
 $ step certificate create --profile root-ca \
   --kms 'pkcs11:module-path=/usr/local/lib/softhsm/libsofthsm2.so;token=smallstep?pin-value=password' \
-  --key 'pkcs11:id=2000'
+  --key 'pkcs11:id=2000' \
   "Smallstep Root CA" root_ca.crt
 Your certificate has been saved in root_ca.crt.
 ```


### PR DESCRIPTION
### Description

This PR fixes the re-opening of a kms when importing a certificate. The YubiKey KMS was failing because it doesn't allow two simmultaneous connections to it.