### PR TITLE
Use Go 1.19.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PKG?=github.com/smallstep/step-kms-plugin
 BINNAME?=step-kms-plugin
-GOLANG_CROSS_VERSION?=v1.19.0
+GOLANG_CROSS_VERSION?=v1.19.2
 
 # Set V to 1 for verbose output from the Makefile
 Q=$(if $V,,@)


### PR DESCRIPTION
### Description

This release upgrades the golangcross version to v1.19.2 to compile with the latest version of Go.