### PR TITLE
Upgrade goreleaser-cross to v1.19.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PKG?=github.com/smallstep/step-kms-plugin
 BINNAME?=step-kms-plugin
-GOLANG_CROSS_VERSION?=v1.19.3
+GOLANG_CROSS_VERSION?=v1.19.5
 
 # Set V to 1 for verbose output from the Makefile
 Q=$(if $V,,@)


### PR DESCRIPTION
### Description

This PR upgrades goreleaser-cross to v1.19.5 which uses the latest version of Go.