### PR TITLE
Add job to create docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,12 @@ jobs:
     name: Create Release
     needs: ci
     runs-on: ubuntu-latest
+    env:
+      DOCKER_IMAGE: smallstep/step-kms-plugin
+    outputs:
+      version: ${{ steps.extract-tag.outputs.VERSION }}
+      is_prerelease: ${{ steps.is_prerelease.outputs.IS_PRERELEASE }}
+      docker_tags: ${{ env.DOCKER_TAGS }}
     steps:
       - name: Is Pre-release
         id: is_prerelease
@@ -24,6 +30,12 @@ jobs:
           OUT=$?
           if [ $OUT -eq 0 ]; then IS_PRERELEASE=true; else IS_PRERELEASE=false; fi
           echo "IS_PRERELEASE=${IS_PRERELEASE}" >> ${GITHUB_OUTPUT}
+      - name: Extract Tag Names
+        id: extract-tag
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "VERSION=${VERSION}" >> ${GITHUB_OUTPUT}
+          echo "DOCKER_TAGS=${{ env.DOCKER_IMAGE }}:${VERSION}" >> ${GITHUB_ENV}
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -34,6 +46,10 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: ${{ steps.is_prerelease.outputs.IS_PRERELEASE }}
+      - name: Add Latest Tag
+        if: steps.is_prerelease.outputs.IS_PRERELEASE == 'false'
+        run: |
+          echo "DOCKER_TAGS=${{ env.DOCKER_TAGS }},${{ env.DOCKER_IMAGE }}:latest" >> ${GITHUB_ENV}
 
   goreleaser:
     name: Upload Assets to Github w/ goreleaser
@@ -57,3 +73,17 @@ jobs:
           echo 'GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}' > .release-env
       - name: release publish
         run: make release
+
+  build_upload_docker:
+    name: Build & Upload Docker Images
+    needs: create_release
+    permissions:
+      id-token: write
+      contents: write
+    uses: smallstep/workflows/.github/workflows/docker-buildx-push.yml@main
+    with:
+      platforms: linux/amd64,linux/arm64
+      tags: ${{ needs.create_release.outputs.docker_tags }}
+      docker_image: smallstep/step-kms-plugin
+      docker_file: docker/Dockerfile
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,10 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/v}
           echo "VERSION=${VERSION}" >> ${GITHUB_OUTPUT}
           echo "DOCKER_TAGS=${{ env.DOCKER_IMAGE }}:${VERSION}" >> ${GITHUB_ENV}
+      - name: Add Latest Tag
+        if: steps.is_prerelease.outputs.IS_PRERELEASE == 'false'
+        run: |
+          echo "DOCKER_TAGS=${{ env.DOCKER_TAGS }},${{ env.DOCKER_IMAGE }}:latest" >> ${GITHUB_ENV}
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -46,28 +50,16 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: ${{ steps.is_prerelease.outputs.IS_PRERELEASE }}
-      - name: Add Latest Tag
-        if: steps.is_prerelease.outputs.IS_PRERELEASE == 'false'
-        run: |
-          echo "DOCKER_TAGS=${{ env.DOCKER_TAGS }},${{ env.DOCKER_IMAGE }}:latest" >> ${GITHUB_ENV}
 
   goreleaser:
     name: Upload Assets to Github w/ goreleaser
     runs-on: ubuntu-latest
     needs: create_release
     steps:
-      - name: Install dependencies
-        run: sudo apt update && sudo apt install -y libpcsclite-dev
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.19'
-      - name: release dry run
-        run: make release-dry-run
       - name: setup release environment
         run: |-
           echo 'GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}' > .release-env

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,7 +19,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s -w -X cmd.Version={{.Version}} -X cmd.BuildTime={{.Date}}
+      - -s -w -X {{.ModulePath}}/cmd.Version={{.Version}} -X {{.ModulePath}}/cmd.ReleaseDate={{.Date}}
   - id: linux-arm64
     main: ./main.go
     binary: step-kms-plugin
@@ -33,7 +33,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s -w -X cmd.Version={{.Version}} -X cmd.BuildTime={{.Date}}
+      - -s -w -X {{.ModulePath}}/cmd.Version={{.Version}} -X {{.ModulePath}}/cmd.ReleaseDate={{.Date}}
   - id: darwin-amd64
     main: ./main.go
     binary: step-kms-plugin
@@ -47,7 +47,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s -w -X cmd.Version={{.Version}} -X cmd.BuildTime={{.Date}}
+      - -s -w -X {{.ModulePath}}/cmd.Version={{.Version}} -X {{.ModulePath}}/cmd.ReleaseDate={{.Date}}
   - id: darwin-arm64
     main: ./main.go
     binary: step-kms-plugin
@@ -61,7 +61,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s -w -X cmd.Version={{.Version}} -X cmd.BuildTime={{.Date}}
+      - -s -w -X {{.ModulePath}}/cmd.Version={{.Version}} -X {{.ModulePath}}/cmd.ReleaseDate={{.Date}}
   - id: windows-amd64
     main: ./main.go
     binary: step-kms-plugin
@@ -75,7 +75,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s -w -X cmd.Version={{.Version}} -X cmd.BuildTime={{.Date}}
+      - -s -w -X {{.ModulePath}}/cmd.Version={{.Version}} -X {{.ModulePath}}/cmd.ReleaseDate={{.Date}}
 
 archives:
   - id: step-kms-plugin

--- a/Makefile
+++ b/Makefile
@@ -44,21 +44,21 @@ VERSION ?= $(shell [ -d .git ] && git describe --tags --always --dirty="-dev")
 endif
 
 VERSION := $(shell echo $(VERSION) | sed 's/^v//')
+DATE    := $(shell date -u '+%Y-%m-%d %H:%M UTC')
 
 ifdef V
 $(info    GITHUB_REF is $(GITHUB_REF))
 $(info    VERSION is $(VERSION))
+$(info    DATE is $(DATE))
 endif
 
 #########################################
 # Build
 #########################################
 
-DATE    := $(shell date -u '+%Y-%m-%d %H:%M UTC')
-LDFLAGS := -ldflags='-w -X "cmd.Version=$(VERSION)" -X "cmd.BuildTime=$(DATE)"'
+LDFLAGS := -ldflags='-s -w -X "$(PKG)/cmd.Version=$(VERSION)" -X "$(PKG)/cmd.ReleaseDate=$(DATE)"'
 
 build:
-	$Q mkdir -p $(@D)
 	$Q go build -v -o $(PREFIX)bin/$(BINNAME) $(LDFLAGS) $(PKG)
 	@echo "Build Complete!"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:alpine AS builder
+
+WORKDIR /src
+COPY . .
+
+RUN apk add --no-cache git make
+RUN apk add --no-cache gcc musl-dev pkgconf pcsc-lite-dev
+RUN make V=1 build
+
+FROM smallstep/step-cli:latest
+
+COPY --from=builder /src/bin/step-kms-plugin /usr/local/bin/step-kms-plugin
+
+USER root
+RUN apk add --no-cache pcsc-lite pcsc-lite-libs
+USER step
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
### Description

This PR creates docker images for linux/amd64 and linux/arm64. It also fixes the version and release dates when you run `step-kms-plugin version`.

There are rc images in the docker hub, you can run them with:
```
docker run -it smallstep/step-kms-plugin:0.5.1-rc2
```