### PR TITLE
Use older goreleaser-cross image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PKG?=github.com/smallstep/step-kms-plugin
 BINNAME?=step-kms-plugin
-GOLANG_CROSS_VERSION?=v1.19.5
+GOLANG_CROSS_VERSION?=v1.19-v1.14.1
 
 # Set V to 1 for verbose output from the Makefile
 Q=$(if $V,,@)


### PR DESCRIPTION
### Description

This PR fixes the build with goreleaser-cross. New releases goreleaser-cross tagged with the previous tag are broken.