### PR TITLE
Add go.work to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 *.so
 *.dylib
 
+# Go Workspaces
+go.work
+go.work.sum
+
 # Development
 bin/
 .vscode/


### PR DESCRIPTION
### Description

This PR adds the files `go.work` and `go.work.sum` to `.gitignore`.