### PR TITLE
Upgrade goreleaser-cross to v1.20.3

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -81,6 +81,7 @@ builds:
 
 archives:
   - id: step-kms-plugin
+    rlcp: true
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
     format_overrides:
       - goos: windows

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PKG?=github.com/smallstep/step-kms-plugin
 BINNAME?=step-kms-plugin
-GOLANG_CROSS_VERSION?=v1.20.2
+GOLANG_CROSS_VERSION?=v1.20.3
 
 # Set V to 1 for verbose output from the Makefile
 Q=$(if $V,,@)


### PR DESCRIPTION
### Description

This commit upgrades `goreleaser-cross` to `v1.20.3`. It also sets the required `archives.rlcp` to true to `.goreleaser.yaml`
