### PR TITLE
Use goreleaser-cross with Go v1.20.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PKG?=github.com/smallstep/step-kms-plugin
 BINNAME?=step-kms-plugin
-GOLANG_CROSS_VERSION?=v1.20.4
+GOLANG_CROSS_VERSION?=v1.20.5
 
 # Set V to 1 for verbose output from the Makefile
 Q=$(if $V,,@)


### PR DESCRIPTION
### Description

goreleaser-cross v1.20.5 has just been tagged. This PR upgrades the version we use to that one. 