### PR TITLE
Add section on p11-kit integration

### DIFF
--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -4,8 +4,7 @@ WORKDIR /src
 COPY . .
 
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
-               gcc pkgconf libpcsclite-dev
+RUN apt-get install -y --no-install-recommends gcc pkgconf libpcsclite-dev
 RUN make V=1 build
 
 FROM smallstep/step-cli:bullseye
@@ -14,7 +13,7 @@ COPY --from=builder /src/bin/step-kms-plugin /usr/local/bin/step-kms-plugin
 
 USER root
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends pcscd libpcsclite1
+RUN apt-get install -y --no-install-recommends pcscd libpcsclite1 p11-kit p11-kit-modules
 USER step
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
### Description

This PR adds a section in the `step-kms-plugin` `README.md` introducing the `p11-kit` integration. It also adds `p11-kit` and `p11-kit-modules` (`p11-kit-proxy.so`) packages to the Debian image. I haven't added them to the Alpine image because `p11-kit-proxy.so` is not yet available in the stable versions, and PKCS #11 modules are usually not supported on a musl-based distributions.