### PR TITLE
doc: add example using pin-source method

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ The commands under `step kms` will directly call `step-kms-plugin` with the
 given arguments. For example, these two commands are equivalent:
 
 ```console
-step kms create --kty EC --crv P384 'pkcs11:token=smallstep;id=1000;object=mykey?pin-value=password'
-step-kms-plugin create --kty EC --crv P384 'pkcs11:token=smallstep;id=1000;object=mykey?pin-value=password'
+step kms create --kty EC --crv P384 'pkcs11:token=smallstep;id=1000;object=mykey?pin-source=/dev/shm/pass.txt'
+step-kms-plugin create --kty EC --crv P384 'pkcs11:token=smallstep;id=1000;object=mykey?pin-source=/dev/shm/pass.txt'
 ```
 
 For the rest of the examples, we are going to use the plugin usage, `step kms`,


### PR DESCRIPTION
#### Name of feature:
Add example of using `pin-source` method to main `README.md`

#### Pain or issue this feature alleviates:
Usage examples in the `README.md` all use `pin-value`, giving the [impression](https://github.com/smallstep/step-kms-plugin/issues/94) the PIN must be passed in [insecurely](https://smallstep.com/blog/command-line-secrets/#directly-in-the-command) via command-line. 

There is a single example usage of `pin-source` in [key.go](https://github.com/smallstep/step-kms-plugin/blob/main/cmd/key.go#L42), but this is easily missed.

This pull request changes the first two usage examples to use the `pin-source` method, to better call out this [more secure method](https://smallstep.com/blog/command-line-secrets/) of providing the pin. 

#### Supporting links/other PRs/issues:
- [README.md - General Usage](https://github.com/smallstep/step-kms-plugin/blob/main/README.md#general-usage)
- [key.go Line 42](https://github.com/smallstep/step-kms-plugin/blob/main/cmd/key.go#L42)
- [How to Handle Secrets on the Command Line](https://smallstep.com/blog/command-line-secrets/)
- Closes #94