### PR TITLE
Use the same version of debian

### DIFF
--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -1,4 +1,4 @@
-FROM golang AS builder
+FROM golang:bullseye AS builder
 
 WORKDIR /src
 COPY . .


### PR DESCRIPTION
This commit fixes a glibc incompatibility when compiling CGO code with debian bookworm and running it in debian bullseye.

We are not upgrading this to bookworm yet, because other docker images like the one for step-ca are still in bullseye and they depend on this.
