### PR TITLE
Upgrade goreleaser-cross version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -95,7 +95,6 @@ builds:
 
 archives:
   - id: step-kms-plugin
-    rlcp: true
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
     format_overrides:
       - goos: windows

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PKG?=github.com/smallstep/step-kms-plugin
 BINNAME?=step-kms-plugin
-GOLANG_CROSS_VERSION?=v1.20.5
+GOLANG_CROSS_VERSION?=v1.21.4
 
 # Set V to 1 for verbose output from the Makefile
 Q=$(if $V,,@)
@@ -120,7 +120,7 @@ release-dry-run:
 		-v `pwd`:/go/src/$(PKG) \
 		-w /go/src/$(PKG) \
 		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-		--clean --skip-validate --skip-publish
+		--clean --skip=validate --skip=publish
 
 release:
 	@if [ ! -f ".release-env" ]; then \


### PR DESCRIPTION
This commit upgrades the version to goreleaser and goreleaser-cross versions.
