### PR TITLE
Docker: Update Debian base image to use bookworm base image and builder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       DOCKER_IMAGE: smallstep/step-kms-plugin
       CLOUD_TAG: cloud
-      DEBIAN_TAG: bullseye
+      DEBIAN_TAG: bookworm 
       WOLFI_TAG: wolfi
     outputs:
       version: ${{ steps.extract-tag.outputs.VERSION }}

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -1,4 +1,4 @@
-FROM golang:bullseye AS builder
+FROM golang:bookworm AS builder
 
 WORKDIR /src
 COPY . .
@@ -7,7 +7,7 @@ RUN apt-get update
 RUN apt-get install -y --no-install-recommends gcc pkgconf libpcsclite-dev
 RUN make V=1 build
 
-FROM smallstep/step-cli:bullseye
+FROM smallstep/step-cli:bookworm
 
 COPY --from=builder /src/bin/step-kms-plugin /usr/local/bin/step-kms-plugin
 


### PR DESCRIPTION
I've tested that `step-kms-plugin` builds and runs properly using the `debian:bookworm` base image and `golang:bookworm` builder image

Note: https://github.com/smallstep/cli/pull/1080 will need to be merged and released before this will build.
