### PR TITLE
Upgrade goreleaser-cross to v1.24

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -98,7 +98,7 @@ archives:
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [ 'zip' ]
     builds:
       - linux-amd64
       - linux-arm64
@@ -161,7 +161,7 @@ checksum:
   name_template: "checksums.txt"
 
 snapshot:
-  name_template: "{{ .Tag }}"
+  version_template: "{{ .Tag }}"
 
 changelog:
   sort: asc

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PKG?=github.com/smallstep/step-kms-plugin
 BINNAME?=step-kms-plugin
-GOLANG_CROSS_VERSION?=v1.22
+GOLANG_CROSS_VERSION?=v1.24
 
 # Set V to 1 for verbose output from the Makefile
 Q=$(if $V,,@)


### PR DESCRIPTION
### Description 

This commit upgrades goreleaser-cross to the latest version. This version includes a new version of goreleaser that deprecates some parameters, this commit upgrades those parameters to use the new version.

This should fix an issue with the CI when Go builds the Go toolchain because the go.mod was using a newer version.
