### PR TITLE
Fix missing architectures in default repo

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -112,7 +112,7 @@ archives:
     format_overrides:
       - goos: windows
         formats: [ 'zip' ]
-    builds:
+    ids:
       - linux-amd64
       - linux-arm64
       - darwin-amd64
@@ -127,7 +127,7 @@ archives:
 
 nfpms:
   - id: packages
-    builds:
+    ids:
       - linux-amd64
       - linux-arm64
     package_name: "{{ .Var.packageName }}"

--- a/docker/build/entrypoint.sh
+++ b/docker/build/entrypoint.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+# Fix for missing bullseye repos:
+echo 'deb http://archive.debian.org/debian bullseye main
+deb http://deb.debian.org/debian-security bullseye-security main
+deb http://archive.debian.org/debian bullseye-updates main' > /etc/apt/sources.list
+
 apt update
 apt install --no-install-recommends -y curl pkg-config libpcsclite-dev libpcsclite-dev:arm64
 


### PR DESCRIPTION
This commit updates the apt sources.list to use debian archive, this fixes an error in the "apt update" command of the entrypoint.

This also fixes the deprecation notices of goreleaser
