### PR TITLE
Upgrade goreleaser-cross to v1.25

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PKG?=github.com/smallstep/step-kms-plugin
 BINNAME?=step-kms-plugin
-GOLANG_CROSS_VERSION?=v1.24
+GOLANG_CROSS_VERSION?=v1.25
 
 # Set V to 1 for verbose output from the Makefile
 Q=$(if $V,,@)


### PR DESCRIPTION
This commit upgrades the goreleaser-cross version to v1.25. This version uses the latest release of Go.
