### PR TITLE
Prepare release with Go 1.26

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,7 @@ version: 2
 variables:
   packageName: step-kms-plugin
   packageRelease: 1 # Manually update release: in the nfpm section to match this value if you change this
+  macosTarget: 14.0.0
 
 after:
   hooks:
@@ -57,7 +58,9 @@ builds:
     env:
       - CC=o64-clang
       - CXX=o64-clang++
-      - LD_LIBRARY_PATH=/osxcross/lib
+      - LD_LIBRARY_PATH=/usr/local/osxcross/lib
+      - CGO_CFLAGS="-mmacosx-version-min={{ .Var.macosTarget }}"
+      - CGO_LDFLAGS="-mmacosx-version-min={{ .Var.macosTarget }}"
     flags:
       - -trimpath
     ldflags:
@@ -72,7 +75,9 @@ builds:
     env:
       - CC=oa64-clang
       - CXX=oa64-clang++
-      - LD_LIBRARY_PATH=/osxcross/lib
+      - LD_LIBRARY_PATH=/usr/local/osxcross/lib
+      - CGO_CFLAGS="-mmacosx-version-min={{ .Var.macosTarget }}"
+      - CGO_LDFLAGS="-mmacosx-version-min={{ .Var.macosTarget }}"
     flags:
       - -trimpath
     ldflags:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PKG?=github.com/smallstep/step-kms-plugin
 BINNAME?=step-kms-plugin
-GOLANG_CROSS_VERSION?=v1.25
+GOLANG_CROSS_VERSION?=v1.26
 
 # Set V to 1 for verbose output from the Makefile
 Q=$(if $V,,@)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It can be used independently, or as a plugin for [`step`](https://github.com/sma
 
 ## Installation
 
-There's two installation options:
+There are two installation options:
 
 - The most generic way to install `step-kms-plugin` is to use `go install` to
 compile it and install it in your `$GOBIN`, which defaults to `$(go env GOPATH)/bin`.
@@ -27,13 +27,15 @@ add it to your `$PATH` or to `$(step path --base)/plugins`.
 The following Key Management Systems (KMSs) are supported, but not all of
 them provide the full functionality:
 
-* PKCS #11 modules
-* [TPM 2.0](https://trustedcomputinggroup.org/resource/tpm-library-specification/)
-* [Amazon AWS KMS](https://aws.amazon.com/kms/)
-* [Google Cloud Key Management](https://cloud.google.com/security-key-management)
-* [Microsoft Azure Key Vault](https://azure.microsoft.com/en-us/services/key-vault/)
-* [YubiKey PIV](https://developers.yubico.com/PIV/)
-* ssh-agent
+* PKCS #11 modules (`pkcs11:`)
+* Platform KMS using TPM KMS on linux and windows and keychain and Secure Enclave on macOS (`kms:`)
+* [TPM 2.0](https://trustedcomputinggroup.org/resource/tpm-library-specification/) (`tpmkms:`)
+* [Amazon AWS KMS](https://aws.amazon.com/kms/) (`awskms:`)
+* [Google Cloud Key Management](https://cloud.google.com/security-key-management) (`cloudkms:`)
+* [Microsoft Azure Key Vault](https://azure.microsoft.com/en-us/services/key-vault/) (`azurekms:`)
+* [YubiKey PIV](https://developers.yubico.com/PIV/) (`yubikey:`)
+* macOS keychain and Secure Enclave on signed binaries (`mackms:`).
+* ssh-agent (`sshagentkms:`)
 
 ## Setting up `step-ca`?
 
@@ -375,7 +377,7 @@ but the private key is not exportable from the YubiKey.
 First, create a private key on the YubiKey in slot 9a, and output a CSR:
 
 ```
-$ step certificate create --csr --kms 'yubikey:pin-value=123456' --key 'yubikey:slot-id=9a' mariano@smallstep.com mariano.csr
+$ step certificate create --csr -key 'yubikey:slot-id=9a?pin-value=123456' mariano@smallstep.com mariano.csr
 Your certificate signing request has been saved in mariano.csr.
 ```
 
@@ -395,12 +397,11 @@ https://accounts.google.com/o/oauth2/v2/auth?...
 Finally, import the new certificate into the YubiKey:
 
 ```
-$ step kms certificate --import mariano.crt --kms 'yubikey:' 'yubikey:slot-id=9a'
+$ step kms certificate copy mariano.crt 'yubikey:slot-id=9a'
 -----BEGIN CERTIFICATE-----
 MIICQjCCAeigAwIBAgIRANfNWEXAMPLE3zJ+jRZ4TbUwCgYIKoZIzj0EAwIwKTEn
 ...
 -----END CERTIFICATE-----
-
 ```
 
 Note: To use this client certificate against a server, the server needs to trust the intermediate CA rather than the root CA. That's because YubiKeys only support one certificate per key slot (in this case, the client certificate). On your server, you can either trust the intermediate by itself, or a PEM bundle consisting of the intermediate CA first, then the root CA.


### PR DESCRIPTION
This commit updates the goreleaser-cross verson to use Go 1.26.

he release candidate [v0.17.0-rc1](https://github.com/smallstep/step-kms-plugin/releases/tag/v0.17.0-rc1) has been built over this PR.
