### PR TITLE
Assign `actions: read` permission to `actionci` job

### DIFF
--- a/.github/workflows/actionci.yml
+++ b/.github/workflows/actionci.yml
@@ -18,5 +18,6 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
     uses: smallstep/workflows/.github/workflows/actionci.yml@main
     secrets: inherit

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -16,5 +16,5 @@ permissions:
 
 jobs:
   triage:
-    uses: smallstep/workflows/.github/workflows/triage.yml@main
+    uses: smallstep/workflows/.github/workflows/triage.yml@a99d801d470dc7950cba27fba10157f54437a1c7
     secrets: inherit


### PR DESCRIPTION
See https://github.com/smallstep/step-kms-plugin/actions/runs/26446185880 for an example of a broken run.